### PR TITLE
Update Miniconda URL from Conda docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # See https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
   #
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi


### PR DESCRIPTION
According to [1], use Miniconda2-latest-Linux-x86_64.sh.  This fixes a build bug on Travis.

[1] https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html, retrieved 2018-12-28.